### PR TITLE
Fix group name comparison

### DIFF
--- a/tiss_quick_registration_script.user.js
+++ b/tiss_quick_registration_script.user.js
@@ -557,10 +557,11 @@
     };
 
     self.getGroupLabel = function (nameOfGroup) {
+        // Normalize group lables and configured group label before comparing.
+        var normConfName = nameOfGroup.trim().replace(/\s\s+/gi, ' ');
+
         return $(".groupWrapper .header_element span").filter(function () {
-            // Normalize group lables and configured group label before comparing.
             var normName = $(this).text().trim().replace(/\s\s+/gi, ' ');
-            var normConfName = nameOfGroup.trim().replace(/\s\s+/gi, ' ');
 
             return normName === normConfName;
         });

--- a/tiss_quick_registration_script.user.js
+++ b/tiss_quick_registration_script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name       TISS Quick Registration Script
 // @namespace  http://www.manuelgeier.com/
-// @version    1.6.0
+// @version    1.6.1
 // @description  Script to help you to get into the group you want. Opens automatically the right panel, registers automatically and confirms your registration automatically. If you don't want the script to do everything automatically, the focus is already set on the right button, so you only need to confirm. There is also an option available to auto refresh the page, if the registration button is not available yet, so you can open the site and watch the script doing its work. You can also set a specific time when the script should reload the page and start.
 // @match      https://tiss.tuwien.ac.at/*
 // @copyright  2012+, Manuel Geier, THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tiss_quick_registration_script.user.js
+++ b/tiss_quick_registration_script.user.js
@@ -10,6 +10,9 @@
 
 /*
  Changelog:
+ 
+ v.1.6.1 [13.10.2019]
+ ~ Fix: Ignore multiple spaces on group label comparison. (@zarmonious)
 
  v.1.6.0 [28.11.2018]
  + Added: exam-registration support (Thanks to @XtomtomX, #11)
@@ -555,7 +558,11 @@
 
     self.getGroupLabel = function (nameOfGroup) {
         return $(".groupWrapper .header_element span").filter(function () {
-            return $(this).text().trim() === nameOfGroup;
+            // Normalize group lables and configured group label before comparing.
+            var normName = $(this).text().trim().replace(/\s\s+/gi, ' ');
+            var normConfName = nameOfGroup.trim().replace(/\s\s+/gi, ' ');
+
+            return normName === normConfName;
         });
     };
 


### PR DESCRIPTION
Fixes an issue where sometimes admins would [by mistake] enter multiple spaces in group names, which is shown by the browser correctly with single spaces, but fails on comparison with the configured group name, where the user does not know that multiple spaces are present.