### PR TITLE
fixed exam date support

### DIFF
--- a/tiss_quick_registration_script.user.js
+++ b/tiss_quick_registration_script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name       TISS Quick Registration Script
 // @namespace  http://www.manuelgeier.com/
-// @version    1.6.3
+// @version    1.6.4
 // @description  Script to help you to get into the group you want. Opens automatically the right panel, registers automatically and confirms your registration automatically. If you don't want the script to do everything automatically, the focus is already set on the right button, so you only need to confirm. There is also an option available to auto refresh the page, if the registration button is not available yet, so you can open the site and watch the script doing its work. You can also set a specific time when the script should reload the page and start.
 // @match      https://tiss.tuwien.ac.at/*
 // @copyright  2012+, Manuel Geier, THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
@@ -10,7 +10,7 @@
 
 /*
  Changelog:
- v.1.6.3 [21.11.2021]
+ v.1.6.4 [21.11.2021]
  ~ Fix: previously all exams on the correct date were valid, ignoring exam name
  
  v.1.6.3 [18.12.2020]

--- a/tiss_quick_registration_script.user.js
+++ b/tiss_quick_registration_script.user.js
@@ -10,6 +10,8 @@
 
 /*
  Changelog:
+ v.1.6.3 [21.11.2021]
+ ~ Fix: previously all exams on the correct date were valid, ignoring exam name
  
  v.1.6.3 [18.12.2020]
  + Added: date of exam support
@@ -596,7 +598,8 @@
             var examData = $(this).text().trim();
             var examLabel = self.getExamLabel(nameOfExam).first().text().trim() + " ";
             var examDate = examData.replace(examLabel, '');
-            return examDate.match(dateOfExam);
+            var examRemainder = examDate.replace(dateOfExam, '');
+            return !examRemainder && examData;
         });
     };
 


### PR DESCRIPTION
The previous version was ignoring the exam name as long as the exam date was correct, matching multiple wrong exams in my testing.