### PR TITLE
fix examNotFoundError

### DIFF
--- a/tiss_quick_registration_script.user.js
+++ b/tiss_quick_registration_script.user.js
@@ -587,7 +587,7 @@
     self.getExamLabel = function (nameOfExam) {
         return $(".groupWrapper .header_element span").filter(function () {
             var tmp = $(this).text().trim();
-            return tmp.match(nameOfExam);
+            return tmp == nameOfExam;
         });
     };
 


### PR DESCRIPTION
string comparison with == instead of match.
This caused the examNotFoundError for me.